### PR TITLE
package.json minor fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "javaparser",
+	"version": "0.1.0",
 	"devDependencies": {
 	  "grunt": "~0.4.5",
 	  "grunt-cli": "~0.1",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"name": "javaparser",
 	"devDependencies": {
 	  "grunt": "~0.4.5",
 	  "grunt-cli": "~0.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
-	"name": "javaparser",
+	"name": "jsjavaparser",
+	"main": "lib/javaparser7.js",
 	"version": "0.1.0",
 	"devDependencies": {
 	  "grunt": "~0.4.5",


### PR DESCRIPTION
It's impossible to use jsjavaparser via npm without name and version in package.json
